### PR TITLE
Flesh out basic structure by implementing some debugging commands

### DIFF
--- a/docs/errors.markdown
+++ b/docs/errors.markdown
@@ -1,0 +1,61 @@
+# Errors
+
+API errors are returned in JSON as a [problem details object][], in
+the following format:
+
+```json
+{
+  "type": "URI which identifies the problem type and points to further information",
+  "title": "Short human-readable summary of the problem type",
+  "detail": "Human-readable explanation of this specific instance of the problem."
+}
+```
+
+There may be additional fields named `detail_KEY`.
+
+[problem details object]: https://tools.ietf.org/html/rfc7807
+
+## Podman request returned invalid JSON
+
+Podman returned a successful response but with an unexpected response
+body.
+
+**This could be caused by:**
+
+- an API incompatibility
+- a bug in Ozymandias
+- a bug in Podman
+
+**Before reporting an issue:**
+
+Check you have the latest version of Ozymandias and Podman, and that
+Podman is working.
+
+## Podman request raised an HTTP error
+
+Podman returned an unexpected response.
+
+**This could be caused by:**
+
+- an API incompatibility
+- a bug in Ozymandias
+- a bug in Podman
+
+**Before reporting an issue:**
+
+Check you have the latest version of Ozymandias and Podman, and that
+Podman is working.
+
+## Invalid URL
+
+Ozymandias was unable to query a necessary API because it constructed
+an invalid URL.
+
+**This could be caused by:**
+
+- incorrect configuration
+- a bug in Oxymandias
+
+**Before reporting an issue:**
+
+Check that any URLs you are passing to Ozymandias are correct.

--- a/docs/errors.markdown
+++ b/docs/errors.markdown
@@ -15,14 +15,14 @@ There may be additional fields named `detail_KEY`.
 
 [problem details object]: https://tools.ietf.org/html/rfc7807
 
-## Job has unsatisfiable dependencies
+## Pod has unsatisfiable dependencies
 
-A job configuration has containers with dependencies which either form
+A pod configuration has containers with dependencies which either form
 a loop, or which reference undefined containers.
 
 **This could be caused by:**
 
-- an error in your job configuration
+- an error in your pod configuration
 - a bug in Ozymandias
 
 **Before reporting an issue:**

--- a/docs/errors.markdown
+++ b/docs/errors.markdown
@@ -15,6 +15,21 @@ There may be additional fields named `detail_KEY`.
 
 [problem details object]: https://tools.ietf.org/html/rfc7807
 
+## Job has unsatisfiable dependencies
+
+A job configuration has containers with dependencies which either form
+a loop, or which reference undefined containers.
+
+**This could be caused by:**
+
+- an error in your job configuration
+- a bug in Ozymandias
+
+**Before reporting an issue:**
+
+Check that you don't have any typos or loops in your container
+`depends` specifications.
+
 ## Podman request returned invalid JSON
 
 Podman returned a successful response but with an unexpected response

--- a/docs/errors.markdown
+++ b/docs/errors.markdown
@@ -30,6 +30,52 @@ a loop, or which reference undefined containers.
 Check that you don't have any typos or loops in your container
 `depends` specifications.
 
+## etcd request returned invalid JSON
+
+etcd returned a successful response but with an unexpected response
+body.
+
+**This could be caused by:**
+
+- an API incompatibility
+- a bug in Ozymandias
+- a bug in etcd
+
+**Before reporting an issue:**
+
+Check you have the latest version of Ozymandias and etcd, and that
+etcd is working.
+
+## etcd request raised an HTTP error
+
+etcd returned an unexpected response.
+
+**This could be caused by:**
+
+- an API incompatibility
+- a bug in Ozymandias
+- a bug in etcd
+
+**Before reporting an issue:**
+
+Check you have the latest version of Ozymandias and etcd, and that
+etcd is working.
+
+## etcd key not found
+
+A key which was expected to exist in etcd does not.
+
+**This could be caused by:**
+
+- an API incompatibility
+- a bug in Ozymandias
+- a bug in etcd
+
+**Before reporting an issue:**
+
+Check you have the latest version of Ozymandias and etcd, and that
+etcd is working.
+
 ## Podman request returned invalid JSON
 
 Podman returned a successful response but with an unexpected response

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -17,6 +17,8 @@ library
 executable ozymandias
     main-is:          Main.hs
     build-depends:    base ^>=4.15.0.0
+                    , optparse-applicative ^>=0.16.1.0
                     , ozymandias
     hs-source-dirs:   src/bin
     default-language: Haskell2010
+    ghc-options:      -Wall -Werror

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -10,6 +10,7 @@ maintainer:         mike@barrucadu.co.uk
 
 library
     exposed-modules:  Ozymandias.Job
+                    , Ozymandias.Monad
                     , Ozymandias.Podman
                     , Ozymandias.Problem
     build-depends:    base ^>=4.15.0.0
@@ -19,6 +20,7 @@ library
                     , http-types ^>=0.12.3
                     , network ^>=3.1.2.0
                     , text ^>=1.2.4.0
+                    , transformers ^>=0.5.6.0
                     , unordered-containers ^>=0.2.13.0
     hs-source-dirs:   src/lib
     default-language: Haskell2010

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -9,7 +9,8 @@ author:             Michael Walker
 maintainer:         mike@barrucadu.co.uk
 
 library
-    exposed-modules:  Ozymandias.Podman
+    exposed-modules:  Ozymandias.Job
+                    , Ozymandias.Podman
                     , Ozymandias.Problem
     build-depends:    base ^>=4.15.0.0
                     , aeson ^>=1.5.6.0
@@ -26,6 +27,7 @@ library
 executable ozymandias
     main-is:          Main.hs
     build-depends:    base ^>=4.15.0.0
+                    , aeson
                     , optparse-applicative ^>=0.16.1.0
                     , ozymandias
                     , text

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -9,10 +9,18 @@ author:             Michael Walker
 maintainer:         mike@barrucadu.co.uk
 
 library
-    exposed-modules:  MyLib
+    exposed-modules:  Ozymandias.Podman
     build-depends:    base ^>=4.15.0.0
+                    , aeson ^>=1.5.6.0
+                    , bytestring ^>=0.11.1.0
+                    , http-client ^>=0.7.6
+                    , http-types ^>=0.12.3
+                    , network ^>=3.1.2.0
+                    , text ^>=1.2.4.0
+                    , unordered-containers ^>=0.2.13.0
     hs-source-dirs:   src/lib
     default-language: Haskell2010
+    ghc-options:      -Wall -Werror
 
 executable ozymandias
     main-is:          Main.hs

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -14,6 +14,7 @@ library
                     , Ozymandias.Monad
                     , Ozymandias.Podman
                     , Ozymandias.Problem
+                    , Ozymandias.Util
     build-depends:    base ^>=4.15.0.0
                     , aeson ^>=1.5.6.0
                     , async ^>=2.2.3

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -10,7 +10,7 @@ maintainer:         mike@barrucadu.co.uk
 
 library
     exposed-modules:  Ozymandias.Etcd
-                    , Ozymandias.Job
+                    , Ozymandias.Pod
                     , Ozymandias.Monad
                     , Ozymandias.Podman
                     , Ozymandias.Problem

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -9,13 +9,15 @@ author:             Michael Walker
 maintainer:         mike@barrucadu.co.uk
 
 library
-    exposed-modules:  Ozymandias.Job
+    exposed-modules:  Ozymandias.Etcd
+                    , Ozymandias.Job
                     , Ozymandias.Monad
                     , Ozymandias.Podman
                     , Ozymandias.Problem
     build-depends:    base ^>=4.15.0.0
                     , aeson ^>=1.5.6.0
                     , async ^>=2.2.3
+                    , base64-bytestring ^>=1.2.0.0
                     , bytestring ^>=0.11.1.0
                     , http-client ^>=0.7.6
                     , http-types ^>=0.12.3

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -15,6 +15,7 @@ library
                     , Ozymandias.Problem
     build-depends:    base ^>=4.15.0.0
                     , aeson ^>=1.5.6.0
+                    , async ^>=2.2.3
                     , bytestring ^>=0.11.1.0
                     , http-client ^>=0.7.6
                     , http-types ^>=0.12.3

--- a/ozymandias.cabal
+++ b/ozymandias.cabal
@@ -10,6 +10,7 @@ maintainer:         mike@barrucadu.co.uk
 
 library
     exposed-modules:  Ozymandias.Podman
+                    , Ozymandias.Problem
     build-depends:    base ^>=4.15.0.0
                     , aeson ^>=1.5.6.0
                     , bytestring ^>=0.11.1.0
@@ -27,6 +28,7 @@ executable ozymandias
     build-depends:    base ^>=4.15.0.0
                     , optparse-applicative ^>=0.16.1.0
                     , ozymandias
+                    , text
     hs-source-dirs:   src/bin
     default-language: Haskell2010
     ghc-options:      -Wall -Werror

--- a/src/bin/Main.hs
+++ b/src/bin/Main.hs
@@ -8,6 +8,7 @@ import Data.Foldable (traverse_)
 import Data.Text (unpack)
 import Options.Applicative
 import Ozymandias.Job
+import Ozymandias.Monad
 import Ozymandias.Podman
 import Ozymandias.Problem
 import System.Exit (die)
@@ -76,7 +77,7 @@ parser =
 
 debugListPods :: Podman -> IsManaged -> IO ()
 debugListPods podman isManaged =
-  getAllPods podman >>= \case
+  runOz (getAllPods podman) >>= \case
     Right allPods ->
       let pods = filter (\p -> podIsManaged p == isManaged) allPods
        in if null pods
@@ -97,7 +98,7 @@ debugCreatePodFromJob podman fp =
   A.eitherDecodeFileStrict fp >>= \case
     Right jobspec -> case normaliseJobSpec jobspec of
       Right njobspec ->
-        createAndLaunchPod podman njobspec >>= \case
+        runOz (createAndLaunchPod podman njobspec) >>= \case
           Right pod -> print pod
           Left err -> die (formatProblem err)
       Left err -> die (formatProblem err)

--- a/src/bin/Main.hs
+++ b/src/bin/Main.hs
@@ -7,6 +7,7 @@ import qualified Data.Aeson as A
 import Data.Foldable (traverse_)
 import Data.Text (pack, unpack)
 import Options.Applicative
+import Ozymandias.Etcd
 import Ozymandias.Job
 import Ozymandias.Monad
 import Ozymandias.Podman
@@ -17,11 +18,13 @@ main :: IO ()
 main = do
   args <- parseArgs
   podman <- initPodman (argsPodmanSocket args)
+  etcd <- initEtcd (argsEtcdHost args)
   case argsCommand args of
     DebugArgs ListManagedPods -> debugListPods podman IsManaged
     DebugArgs ListUnmanagedPods -> debugListPods podman IsNotManaged
     DebugArgs (ParseJobDefinition fp) -> debugParseJobDefinition fp
-    DebugArgs (CreatePodFromJob fp) -> debugCreatePodFromJob podman fp
+    DebugArgs (CreatePodFromFile fp) -> debugCreatePodFromFile podman fp
+    DebugArgs (CreatePodFromEtcd key) -> debugCreatePodFromEtcd etcd podman key
     DebugArgs (DestroyPod pid) -> debugDestroyPod podman pid
   where
     parseArgs =
@@ -36,7 +39,8 @@ main = do
 
 data Args = Args
   { argsCommand :: CommandArgs,
-    argsPodmanSocket :: FilePath
+    argsPodmanSocket :: FilePath,
+    argsEtcdHost :: String
   }
   deriving (Show)
 
@@ -47,7 +51,8 @@ data DebugArgs
   = ListManagedPods
   | ListUnmanagedPods
   | ParseJobDefinition FilePath
-  | CreatePodFromJob FilePath
+  | CreatePodFromFile FilePath
+  | CreatePodFromEtcd String
   | DestroyPod String
   deriving (Show)
 
@@ -58,14 +63,16 @@ parser =
       [ ("debug", "Debugging commands", debugArgs)
       ]
     <*> opt 'P' "podman-socket" "SOCKET" "Path to Podman socket"
+    <*> opt 'E' "etcd-host" "URL" "URL of etcd host"
   where
     debugArgs =
       DebugArgs
         <$> commands
           [ ("list-managed-pods", "List running pods managed by the cluster", pure ListManagedPods),
             ("list-unmanaged-pods", "List running pods not managed by the cluster", pure ListUnmanagedPods),
-            ("parse-job-definition", "Read and dump a job configuration file", ParseJobDefinition <$> opt 'c' "config-file" "FILE" "Path to job configuration file"),
-            ("create-pod-from-job", "Create a pod from a job configuration file", CreatePodFromJob <$> opt 'c' "config-file" "FILE" "Path to job configuration file"),
+            ("parse-job-definition", "Read and dump a job configuration file", ParseJobDefinition <$> opt 'f' "config-file" "FILE" "Path to job configuration file"),
+            ("create-pod-from-file", "Create a pod from a job configuration file", CreatePodFromFile <$> opt 'f' "config-file" "FILE" "Path to job configuration file"),
+            ("create-pod-from-etcd", "Create a pod from a job configuration in etcd", CreatePodFromEtcd <$> opt 'k' "key" "KEY" "Key to read job configuration from"),
             ("destroy-pod", "Kill and delete a running pod", DestroyPod <$> opt 'p' "pod" "POD" "Identifier of the pod")
           ]
 
@@ -93,16 +100,25 @@ debugParseJobDefinition fp =
       Left err -> die (formatProblem err)
     Left err -> die (formatError "Could not parse JSON" err)
 
-debugCreatePodFromJob :: Podman -> FilePath -> IO ()
-debugCreatePodFromJob podman fp =
+debugCreatePodFromFile :: Podman -> FilePath -> IO ()
+debugCreatePodFromFile podman fp =
   A.eitherDecodeFileStrict fp >>= \case
-    Right jobspec -> case normaliseJobSpec jobspec of
-      Right njobspec ->
-        runOz (createAndLaunchPod njobspec podman) >>= \case
-          Right pod -> print pod
-          Left err -> die (formatProblem err)
-      Left err -> die (formatProblem err)
+    Right jobspec -> debugCreatePod podman jobspec
     Left err -> die (formatError "Could not parse JSON" err)
+
+debugCreatePodFromEtcd :: Etcd -> Podman -> String -> IO ()
+debugCreatePodFromEtcd etcd podman key =
+  runOz (fetchJobSpec (EtcdKey (pack key)) etcd) >>= \case
+    Right jobspec -> debugCreatePod podman jobspec
+    Left err -> die (formatProblem err)
+
+debugCreatePod :: Podman -> JobSpec -> IO ()
+debugCreatePod podman jobspec = case normaliseJobSpec jobspec of
+  Right njobspec ->
+    runOz (createAndLaunchPod njobspec podman) >>= \case
+      Right pod -> print pod
+      Left err -> die (formatProblem err)
+  Left err -> die (formatProblem err)
 
 debugDestroyPod :: Podman -> String -> IO ()
 debugDestroyPod podman pid =

--- a/src/bin/Main.hs
+++ b/src/bin/Main.hs
@@ -1,8 +1,58 @@
-module Main where
+module Main (main) where
 
-import qualified MyLib (someFunc)
+import Options.Applicative
+import System.Exit (die)
 
 main :: IO ()
-main = do
-  putStrLn "Hello, Haskell!"
-  MyLib.someFunc
+main = parseArgs >>= runCommand
+  where
+    parseArgs =
+      customExecParser
+        (prefs showHelpOnEmpty)
+        ( info
+            (args <**> helper)
+            (fullDesc <> progDesc "A decentralised container scheduler")
+        )
+
+    runCommand cmd = do
+      print cmd
+      die "unimplemented"
+
+-------------------------------------------------------------------------------
+
+data Args = Args
+  { argsCommand :: CommandArgs,
+    argsPodmanSocket :: FilePath
+  }
+  deriving (Show)
+
+newtype CommandArgs = DebugArgs DebugArgs
+  deriving (Show)
+
+data DebugArgs
+  = ListManagedPods
+  | ListUnmanagedPods
+  | CreatePod FilePath
+  | DestroyPod String
+  deriving (Show)
+
+args :: Parser Args
+args =
+  Args
+    <$> commands
+      [ ("debug", "Debugging commands", debugArgs)
+      ]
+    <*> opt 'P' "podman-socket" "SOCKET" "Path to Podman socket"
+  where
+    debugArgs =
+      DebugArgs
+        <$> commands
+          [ ("list-managed-pods", "List running pods managed by the cluster", pure ListManagedPods),
+            ("list-unmanaged-pods", "List running pods not managed by the cluster", pure ListUnmanagedPods),
+            ("create-pod", "Create a pod from a configuration file", CreatePod <$> opt 'c' "config-file" "FILE" "Path to pod configuration file"),
+            ("destroy-pod", "Kill and delete a running pod", DestroyPod <$> opt 'p' "pod" "POD" "Identifier of the pod")
+          ]
+
+    opt sname lname mvar htext = strOption $ short sname <> long lname <> metavar mvar <> help htext
+
+    commands = hsubparser . mconcat . map (\(name, desc, cmd) -> command name (cmd `info` progDesc desc))

--- a/src/bin/Main.hs
+++ b/src/bin/Main.hs
@@ -7,7 +7,7 @@ import qualified Data.Aeson as A
 import Data.Foldable (traverse_)
 import Data.Text (unpack)
 import Options.Applicative
-import Ozymandias.Job (JobSpec)
+import Ozymandias.Job
 import Ozymandias.Podman
 import Ozymandias.Problem
 import System.Exit (die)
@@ -86,7 +86,9 @@ debugListPods podman isManaged =
 debugParseJobDefinition :: FilePath -> IO ()
 debugParseJobDefinition fp =
   A.eitherDecodeFileStrict fp >>= \case
-    Right jobspec -> print (jobspec :: JobSpec)
+    Right jobspec -> case normaliseJobSpec jobspec of
+      Right njobspec -> print njobspec
+      Left err -> die (formatProblem err)
     Left err -> die (formatError "Could not parse JSON" err)
 
 -------------------------------------------------------------------------------

--- a/src/bin/Main.hs
+++ b/src/bin/Main.hs
@@ -108,21 +108,21 @@ debugCreatePodFromFile podman fp =
 
 debugCreatePodFromEtcd :: Etcd -> Podman -> String -> IO ()
 debugCreatePodFromEtcd etcd podman key =
-  runOz (fetchJobSpec (EtcdKey (pack key)) etcd) >>= \case
+  runOz (fetchJobSpec etcd (EtcdKey (pack key))) >>= \case
     Right jobspec -> debugCreatePod podman jobspec
     Left err -> die (formatProblem err)
 
 debugCreatePod :: Podman -> JobSpec -> IO ()
 debugCreatePod podman jobspec = case normaliseJobSpec jobspec of
   Right njobspec ->
-    runOz (createAndLaunchPod njobspec podman) >>= \case
+    runOz (createAndLaunchPod podman njobspec) >>= \case
       Right pod -> print pod
       Left err -> die (formatProblem err)
   Left err -> die (formatProblem err)
 
 debugDestroyPod :: Podman -> String -> IO ()
 debugDestroyPod podman pid =
-  runOz (destroyPod (IdObj (pack pid)) podman) >>= \case
+  runOz (destroyPod podman (IdObj (pack pid))) >>= \case
     Right () -> putStrLn ("Pod " <> pid <> " destroyed.")
     Left err -> die (formatProblem err)
 

--- a/src/lib/MyLib.hs
+++ b/src/lib/MyLib.hs
@@ -1,4 +1,0 @@
-module MyLib (someFunc) where
-
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"

--- a/src/lib/Ozymandias/Etcd.hs
+++ b/src/lib/Ozymandias/Etcd.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ozymandias.Etcd
+  ( -- * The etcd handle
+    Etcd,
+    initEtcd,
+
+    -- * Interacting with etcd
+    EtcdKey (..),
+    fetchJobSpec,
+  )
+where
+
+import Data.Aeson
+import qualified Data.Aeson.Types as A
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.ByteString.Lazy as BL
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Network.HTTP.Client
+import Network.HTTP.Types
+import Ozymandias.Job
+import Ozymandias.Monad
+import Ozymandias.Problem
+
+-------------------------------------------------------------------------------
+
+-- | A handle to the etcd API.
+data Etcd = Etcd
+  { etcdReq :: String -> IO Request,
+    etcdManager :: Manager
+  }
+
+-- | Create a new 'Etcd' handle.
+initEtcd ::
+  -- | URL of the etcd host.
+  String ->
+  IO Etcd
+initEtcd etcdHost = do
+  manager <- newManager defaultManagerSettings
+  pure Etcd {etcdReq = \uriPath -> parseUrlThrow (etcdHost <> uriPath), etcdManager = manager}
+
+-------------------------------------------------------------------------------
+
+-- | A reference to an object in etcd.
+newtype EtcdKey = EtcdKey Text
+  deriving (Show)
+
+-- | Fetch a 'JobSpec' from etcd.
+fetchJobSpec :: EtcdKey -> Etcd -> Oz JobSpec
+fetchJobSpec key = fmap (kvValue . NE.head) . readKey key
+
+-------------------------------------------------------------------------------
+
+-- Lower-level etcd operations used by the functions above.
+
+-- | A collection of keys/values.
+newtype KVs a = KVs [KV a]
+  deriving (Show)
+
+instance FromJSON a => FromJSON (KVs a) where
+  parseJSON = withObject "KVs" $ \v ->
+    KVs
+      <$> fmap (fromMaybe []) (v .:? "kvs")
+
+-- | A single key/value
+data KV a = KV
+  { kvKey :: Text,
+    kvValue :: a,
+    kvVersion :: Text
+  }
+  deriving (Show)
+
+instance FromJSON a => FromJSON (KV a) where
+  parseJSON = withObject "KV" $ \v ->
+    KV
+      <$> fmap decodeTextFromBase64 (v .: "key")
+      <*> (parseJSONFromBase64 =<< (v .: "value"))
+      <*> v .: "version"
+
+-- | Fetch the value at a key.
+readKey :: FromJSON a => EtcdKey -> Etcd -> Oz (NonEmpty (KV a))
+readKey (EtcdKey key) etcd = do
+  let j = object ["key" .= encodeTextAsBase64 key]
+  KVs values <- etcdApiRequest methodPost "/v3alpha/kv/range" (Just j) etcd
+  maybe (problem (EtcdKeyNotFoundError key)) pure (NE.nonEmpty values)
+
+-------------------------------------------------------------------------------
+
+-- | Parse some JSON from base64 data
+parseJSONFromBase64 :: FromJSON a => Text -> A.Parser a
+parseJSONFromBase64 = either fail pure . eitherDecode . BL.fromStrict . B64.decodeLenient . encodeUtf8
+
+-- | Decode some @Text@ from base64 data.
+decodeTextFromBase64 :: Text -> Text
+decodeTextFromBase64 = decodeUtf8 . B64.decodeLenient . encodeUtf8
+
+-- | Encode some @Text@ into base64 data.
+encodeTextAsBase64 :: Text -> Text
+encodeTextAsBase64 = decodeUtf8 . B64.encode . encodeUtf8
+
+-- | Make a request to the etcd API and decode the response as JSON.
+etcdApiRequest ::
+  FromJSON a =>
+  -- | Request method
+  Method ->
+  -- | Request path
+  String ->
+  -- | JSON request body
+  Maybe Value ->
+  -- | etcd handle
+  Etcd ->
+  Oz a
+etcdApiRequest meth uriPath body manager = decodeJson =<< etcdApiRequest' meth uriPath body manager
+  where
+    decodeJson = either (problem . EtcdJsonError) pure . eitherDecode . responseBody
+
+-- | Make a request to the etcd API.
+etcdApiRequest' ::
+  -- | Request method
+  Method ->
+  -- | Request path
+  String ->
+  -- | JSON request body
+  Maybe Value ->
+  -- | etcd handle
+  Etcd ->
+  Oz (Response BL.ByteString)
+etcdApiRequest' meth uriPath body (Etcd toReq manager) = do
+  req <- makeReq <$> liftIO (toReq uriPath)
+  liftIO (httpLbs req manager) `catch` (problem . EtcdHttpError)
+  where
+    makeReq req =
+      req
+        { method = meth,
+          requestHeaders = [(hAccept, "application/json"), (hContentType, "application/json")],
+          requestBody = maybe (requestBody req) (RequestBodyLBS . encode) body
+        }

--- a/src/lib/Ozymandias/Etcd.hs
+++ b/src/lib/Ozymandias/Etcd.hs
@@ -7,7 +7,7 @@ module Ozymandias.Etcd
 
     -- * Interacting with etcd
     EtcdKey (..),
-    fetchJobSpec,
+    fetchPodSpec,
   )
 where
 
@@ -20,8 +20,8 @@ import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import Ozymandias.Job
 import Ozymandias.Monad
+import Ozymandias.Pod
 import Ozymandias.Problem
 import Ozymandias.Util
 
@@ -54,9 +54,9 @@ initEtcd etcdHost = do
 newtype EtcdKey = EtcdKey Text
   deriving (Show)
 
--- | Fetch a 'JobSpec' from etcd.
-fetchJobSpec :: Etcd -> EtcdKey -> Oz JobSpec
-fetchJobSpec etcd key = kvValue . NE.head <$> readKey etcd key
+-- | Fetch a 'PodSpec' from etcd.
+fetchPodSpec :: Etcd -> EtcdKey -> Oz PodSpec
+fetchPodSpec etcd key = kvValue . NE.head <$> readKey etcd key
 
 -------------------------------------------------------------------------------
 

--- a/src/lib/Ozymandias/Job.hs
+++ b/src/lib/Ozymandias/Job.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Ozymandias.Job
+  ( -- * Job specifications
+    JobSpec (..),
+    ContainerSpec (..),
+    PortMappingSpec (..),
+    RestartPolicySpec (..),
+    PortProtocolSpec (..),
+  )
+where
+
+import Data.Aeson
+import qualified Data.HashMap.Strict as M
+import Data.List (stripPrefix)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Maybe (fromJust)
+import Data.Text (Text)
+import Data.Word (Word16)
+import GHC.Generics
+import Numeric.Natural (Natural)
+
+-- | A specification of a job to run.
+data JobSpec = JobSpec
+  { -- | The name of the job, to use for DNS.  Must be globally
+    -- unique, and valid as a hostname.
+    jobspecName :: Text,
+    -- | Number of instances to run.
+    jobspecNumInstances :: Natural,
+    -- | Container definitions.  These are run as a single \"pod\",
+    -- bound to the same network interface.
+    jobspecContainers :: M.HashMap Text ContainerSpec
+  }
+  deriving (Generic, Show)
+
+instance ToJSON JobSpec where
+  toJSON = genericToJSON (jsonOptions "jobspec")
+  toEncoding = genericToEncoding (jsonOptions "jobspec")
+
+instance FromJSON JobSpec where
+  parseJSON = genericParseJSON (jsonOptions "jobspec")
+
+-- | A specification of a container to run.
+data ContainerSpec = ContainerSpec
+  { -- | Image to run.
+    containerspecImage :: Text,
+    -- | Restart policy to use.
+    containerspecRestartPolicy :: Maybe RestartPolicySpec,
+    -- | Number of times to try to restart, if the policy is 'on-failure'.
+    containerspecRestartTries :: Maybe Natural,
+    -- | Command to use (if not the image's default).
+    containerspecCommand :: Maybe (NonEmpty Text),
+    -- | Entrypoint to use (if not the image's default).
+    containerspecEntrypoint :: Maybe (NonEmpty Text),
+    -- | Environment variables.
+    containerspecEnvironment :: Maybe (M.HashMap Text Text),
+    -- | Port mappings.
+    containerspecPortMappings :: Maybe [PortMappingSpec],
+    -- | Memory limit, in bytes
+    containerspecMemory :: Natural,
+    -- | Dependencies on other containers in the same pod.
+    containerspecDepends :: Maybe [Text]
+  }
+  deriving (Generic, Show)
+
+instance ToJSON ContainerSpec where
+  toJSON = genericToJSON (jsonOptions "containerspec")
+  toEncoding = genericToEncoding (jsonOptions "containerspec")
+
+instance FromJSON ContainerSpec where
+  parseJSON = genericParseJSON (jsonOptions "containerspec")
+
+-- | A single container port mapping.
+data PortMappingSpec = PortMappingSpec
+  { -- | Port to open on the external IP address.
+    portmappingFrom :: Word16,
+    -- | Port to map to inside the container.
+    portmappingTo :: Word16,
+    -- | Protocols to use (defaults to tcp)
+    portmappingProtocols :: Maybe [PortProtocolSpec]
+  }
+  deriving (Show, Generic)
+
+instance ToJSON PortMappingSpec where
+  toJSON = genericToJSON (jsonOptions "portmapping")
+  toEncoding = genericToEncoding (jsonOptions "portmapping")
+
+instance FromJSON PortMappingSpec where
+  parseJSON = genericParseJSON (jsonOptions "portmapping")
+
+-- | A container's restart policy.
+data RestartPolicySpec = Never | OnFailure | Always
+  deriving (Generic, Show)
+
+instance ToJSON RestartPolicySpec where
+  toJSON = genericToJSON jsonOptions'
+  toEncoding = genericToEncoding jsonOptions'
+
+instance FromJSON RestartPolicySpec where
+  parseJSON = genericParseJSON jsonOptions'
+
+-- | A container port mapping protocol.
+data PortProtocolSpec = TCP | UDP | SCTP
+  deriving (Show, Generic)
+
+instance ToJSON PortProtocolSpec where
+  toJSON = genericToJSON jsonOptions'
+  toEncoding = genericToEncoding jsonOptions'
+
+instance FromJSON PortProtocolSpec where
+  parseJSON = genericParseJSON jsonOptions'
+
+-------------------------------------------------------------------------------
+
+-- | JSON encoding / decoding options for record types.
+jsonOptions :: String -> Options
+jsonOptions prefix = defaultOptions {fieldLabelModifier = camelTo2 '_' . fromJust . stripPrefix prefix}
+
+-- | JSON encoding / decoding options for sum types.
+jsonOptions' :: Options
+jsonOptions' = defaultOptions {constructorTagModifier = camelTo2 '-'}

--- a/src/lib/Ozymandias/Monad.hs
+++ b/src/lib/Ozymandias/Monad.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Ozymandias.Monad
+  ( -- * The @Oz@ monad
+    Oz (..),
+    runOz,
+    problem,
+    catch,
+
+    -- * Re-exports
+    liftIO,
+  )
+where
+
+import qualified Control.Exception as E
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Except
+import Ozymandias.Problem
+
+-- | A type for actions which have effects and might fail with a
+-- 'Problem'.
+newtype Oz a = Oz (ExceptT Problem IO a)
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+-- | Run an @Oz@ action.
+runOz :: Oz a -> IO (Either Problem a)
+runOz (Oz ma) = runExceptT ma
+
+-- | Terminate a computation early with a 'Problem'.
+problem :: Problem -> Oz a
+problem = Oz . throwE
+
+-- | Catch an @IO@ exception
+catch :: E.Exception e => Oz a -> (e -> Oz a) -> Oz a
+catch ma handler = Oz . ExceptT $ runOz ma `E.catch` (runOz . handler)

--- a/src/lib/Ozymandias/Podman.hs
+++ b/src/lib/Ozymandias/Podman.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Ozymandias.Podman
@@ -6,23 +7,31 @@ module Ozymandias.Podman
     initPodman,
 
     -- * Pod types
+    IdObj (..),
     Pod (..),
     IsManaged (..),
 
     -- * Interacting with Podman
+    createAndLaunchPod,
     getAllPods,
   )
 where
 
 import Control.Exception (catch)
+import Control.Monad (void)
 import Data.Aeson
 import qualified Data.ByteString.Lazy as BL
+import Data.Char (toLower)
 import qualified Data.HashMap.Strict as M
-import Data.Text (Text)
+import Data.List (intercalate)
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text, unpack)
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Network.HTTP.Client
-import Network.HTTP.Types (hAccept)
+import Network.HTTP.Types
 import qualified Network.Socket as S
 import qualified Network.Socket.ByteString as SBS
+import Ozymandias.Job
 import Ozymandias.Problem
 
 -------------------------------------------------------------------------------
@@ -44,6 +53,13 @@ initPodman socketPath = Podman <$> newManager defaultManagerSettings {managerRaw
       makeConnection (SBS.recv sock 8096) (SBS.sendAll sock) (S.close sock)
 
 -------------------------------------------------------------------------------
+
+-- | A type for Podman endpoints which return an id.
+newtype IdObj = IdObj Text
+  deriving (Show)
+
+instance FromJSON IdObj where
+  parseJSON = withObject "IdObj" $ \v -> IdObj <$> v .: "Id"
 
 -- | A pod, which is a collection of containers.
 data Pod = Pod
@@ -69,25 +85,142 @@ data IsManaged = IsNotManaged | IsManaged
 
 -------------------------------------------------------------------------------
 
+-- | Create a pod and launch containers inside it.
+createAndLaunchPod :: Podman -> NormalisedJobSpec -> IO (Either Problem IdObj)
+createAndLaunchPod podman njobspec =
+  createPod jobspec podman >>= \case
+    Right pod -> launchContainers pod (normalisedJobSpecToLaunchOrder njobspec)
+    Left err -> pure (Left err)
+  where
+    jobspec = normalisedJobSpecToJobSpec njobspec
+
+    launchContainers :: IdObj -> [[Text]] -> IO (Either Problem IdObj)
+    launchContainers pod = go
+      where
+        go [] = pure (Right pod)
+        go (cs : css) =
+          launchContainersInGroup pod cs >>= \case
+            Right () -> go css
+            Left err -> pure (Left err)
+
+    launchContainersInGroup :: IdObj -> [Text] -> IO (Either Problem ())
+    launchContainersInGroup pod = go
+      where
+        go [] = pure (Right ())
+        go (c : cs) =
+          let container = (jobspecContainers jobspec M.! c)
+           in pullImage (containerspecImage container) podman >>= \case
+                Right _ ->
+                  createContainer pod container podman >>= \case
+                    Right cid ->
+                      initContainer cid podman >>= \case
+                        Right _ ->
+                          startContainer cid podman >>= \case
+                            Right _ -> go cs
+                            Left err -> pure (Left err)
+                        Left err -> pure (Left err)
+                    Left err -> pure (Left err)
+                Left err -> pure (Left err)
+
 -- | List all pods, managed and unmanaged.
 getAllPods :: Podman -> IO (Either Problem [Pod])
-getAllPods = podmanApiRequestJSON "/v3.0.0/libpod/pods/json"
+getAllPods = podmanApiRequest methodGet "/v3.0.0/libpod/pods/json" Nothing
 
 -------------------------------------------------------------------------------
 
--- | Make a request to the Podman API.
-podmanApiRequest :: String -> Podman -> IO (Either Problem (Response BL.ByteString))
-podmanApiRequest uriPath (Podman manager) = (Right <$> doRequest) `catch` (pure . Left . PodmanHttpError)
-  where
-    doRequest = do
-      req <- parseUrlThrow ("http://127.0.0.1" <> uriPath)
-      httpLbs req {requestHeaders = (hAccept, "application/json") : requestHeaders req} manager
+-- Lower-level podman operations used by the functions above.
 
--- | Make a request to the Podman API and decode it as JSON.
-podmanApiRequestJSON :: FromJSON a => String -> Podman -> IO (Either Problem a)
-podmanApiRequestJSON uriPath podman = decodeJson <$> podmanApiRequest uriPath podman
+-- | Create a pod, but not any of its containers.
+createPod :: JobSpec -> Podman -> IO (Either Problem IdObj)
+createPod jobspec = podmanApiRequest methodPost "/v3.0.0/libpod/pods/create" (Just j)
+  where
+    j =
+      object
+        [ "name" .= jobspecName jobspec,
+          "labels" .= object ["managed-by-ozymandias" .= ("yes" :: Text)],
+          "portmappings" .= (map portMappingToJson . concat $ mapMaybe containerspecPortMappings (M.elems (jobspecContainers jobspec)))
+        ]
+
+    portMappingToJson p =
+      object
+        [ "host_port" .= portmappingFrom p,
+          "container_port" .= portmappingTo p,
+          "protocol" .= intercalate "," (map (map toLower . show) (fromMaybe [TCP] (portmappingProtocols p)))
+        ]
+
+-- | Pull an image from a registry.
+pullImage :: Text -> Podman -> IO (Either Problem ())
+pullImage image = fmap void . podmanApiRequest' methodPost uriPath Nothing
+  where
+    uriPath = unpack . decodeUtf8 $ "/v3.0.0/libpod/images/pull?reference=" <> urlEncode True (encodeUtf8 image)
+
+-- | Create, but do not start, a container.
+createContainer :: IdObj -> ContainerSpec -> Podman -> IO (Either Problem IdObj)
+createContainer (IdObj pid) c = podmanApiRequest methodPost "/v3.0.0/libpod/containers/create" (Just j)
+  where
+    j =
+      object
+        [ "pod" .= pid,
+          "image" .= containerspecImage c,
+          "restart_policy" .= containerspecRestartPolicy c,
+          "restart_tries" .= containerspecRestartTries c,
+          "command" .= containerspecCommand c,
+          "entrypoint" .= containerspecEntrypoint c,
+          "env" .= containerspecEnvironment c,
+          "resource_limits" .= object ["memory" .= object ["limit" .= containerspecMemory c]]
+        ]
+
+-- | Initialise, but do not start, a container.
+initContainer :: IdObj -> Podman -> IO (Either Problem ())
+initContainer (IdObj cid) = fmap void . podmanApiRequest' methodPost uriPath Nothing
+  where
+    uriPath = "/v3.0.0/libpod/containers/" <> unpack cid <> "/init"
+
+-- | Start a container.
+startContainer :: IdObj -> Podman -> IO (Either Problem ())
+startContainer (IdObj cid) = fmap void . podmanApiRequest' methodPost uriPath Nothing
+  where
+    uriPath = "/v3.0.0/libpod/containers/" <> unpack cid <> "/start"
+
+-------------------------------------------------------------------------------
+
+-- | Make a request to the Podman API and decode the response as JSON.
+podmanApiRequest ::
+  FromJSON a =>
+  -- | Request method
+  Method ->
+  -- | Request path
+  String ->
+  -- | JSON request body
+  Maybe Value ->
+  -- | Podman handle
+  Podman ->
+  IO (Either Problem a)
+podmanApiRequest meth uriPath body manager = decodeJson <$> podmanApiRequest' meth uriPath body manager
   where
     decodeJson (Right resp) = case eitherDecode (responseBody resp) of
       Right a -> Right a
       Left err -> Left (PodmanJsonError err)
     decodeJson (Left err) = Left err
+
+-- | Make a request to the Podman API.
+podmanApiRequest' ::
+  -- | Request method
+  Method ->
+  -- | Request path
+  String ->
+  -- | JSON request body
+  Maybe Value ->
+  -- | Podman handle
+  Podman ->
+  IO (Either Problem (Response BL.ByteString))
+podmanApiRequest' meth uriPath body (Podman manager) = do
+  req <- makeReq <$> parseUrlThrow ("http://127.0.0.1" <> uriPath)
+  (Right <$> httpLbs req manager) `catch` (pure . Left . PodmanHttpError)
+  where
+    makeReq req =
+      req
+        { method = meth,
+          requestHeaders = [(hAccept, "application/json"), (hContentType, "application/json")],
+          requestBody = maybe (requestBody req) (RequestBodyLBS . encode) body
+        }

--- a/src/lib/Ozymandias/Podman.hs
+++ b/src/lib/Ozymandias/Podman.hs
@@ -12,6 +12,7 @@ module Ozymandias.Podman
 
     -- * Interacting with Podman
     createAndLaunchPod,
+    destroyPod,
     getAllPods,
   )
 where
@@ -85,8 +86,8 @@ data IsManaged = IsNotManaged | IsManaged
 -------------------------------------------------------------------------------
 
 -- | Create a pod and launch containers inside it.
-createAndLaunchPod :: Podman -> NormalisedJobSpec -> Oz IdObj
-createAndLaunchPod podman njobspec = do
+createAndLaunchPod :: NormalisedJobSpec -> Podman -> Oz IdObj
+createAndLaunchPod njobspec podman = do
   pod <- createPod jobspec podman
   launchContainers pod (normalisedJobSpecToLaunchOrder njobspec)
   where
@@ -109,6 +110,12 @@ createAndLaunchPod podman njobspec = do
           initContainer cid podman
           startContainer cid podman
           go cs
+
+-- | Kill and delete a pod and all its containers.
+destroyPod :: IdObj -> Podman -> Oz ()
+destroyPod (IdObj pid) = void . podmanApiRequest' methodDelete uriPath Nothing
+  where
+    uriPath = "/v3.0.0/libpod/pods/" <> unpack pid <> "?force=true"
 
 -- | List all pods, managed and unmanaged.
 getAllPods :: Podman -> Oz [Pod]

--- a/src/lib/Ozymandias/Podman.hs
+++ b/src/lib/Ozymandias/Podman.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ozymandias.Podman
+  ( -- * The Podman handle
+    Podman,
+    initPodman,
+
+    -- * Pod types
+    Pod (..),
+    IsManaged (..),
+
+    -- * Interacting with Podman
+    getAllPods,
+  )
+where
+
+import Data.Aeson
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.HashMap.Strict as M
+import Data.Text (Text)
+import Network.HTTP.Client
+import Network.HTTP.Types (hAccept)
+import qualified Network.Socket as S
+import qualified Network.Socket.ByteString as SBS
+
+-------------------------------------------------------------------------------
+
+-- | A handle to the Podman API.
+newtype Podman = Podman Manager
+
+-- | Create a new 'Podman' handle.
+initPodman ::
+  -- | Path to the Podman UNIX socket file.
+  FilePath ->
+  IO Podman
+initPodman socketPath = Podman <$> newManager defaultManagerSettings {managerRawConnection = pure openUnixSocket}
+  where
+    -- from https://kseo.github.io/posts/2017-01-23-custom-connection-manager-for-http-client.html
+    openUnixSocket _ _ _ = do
+      sock <- S.socket S.AF_UNIX S.Stream S.defaultProtocol
+      S.connect sock (S.SockAddrUnix socketPath)
+      makeConnection (SBS.recv sock 8096) (SBS.sendAll sock) (S.close sock)
+
+-------------------------------------------------------------------------------
+
+-- | A pod, which is a collection of containers.
+data Pod = Pod
+  { -- | Internal identifier of the pod, used to manipulate it.
+    podId :: Text,
+    -- | Human-friendly (somewhat) name of the pod.
+    podName :: Text,
+    -- | Whether this pod is managed by Ozymandias or not.
+    podIsManaged :: IsManaged
+  }
+  deriving (Show)
+
+instance FromJSON Pod where
+  parseJSON = withObject "Pod" $ \v ->
+    Pod
+      <$> v .: "Id"
+      <*> v .: "Name"
+      <*> ((\labels -> if M.member "managed-by-ozymandias" (labels :: Object) then IsManaged else IsNotManaged) <$> (v .: "Labels"))
+
+-- | Whether a pod is managed by Ozymandias or not.
+data IsManaged = IsNotManaged | IsManaged
+  deriving (Eq, Ord, Read, Show, Enum, Bounded)
+
+-------------------------------------------------------------------------------
+
+-- | List all pods, managed and unmanaged.
+getAllPods :: Podman -> IO [Pod]
+getAllPods podman = decodeWithError . responseBody <$> podmanApiRequest podman "/v3.0.0/libpod/pods/json"
+
+-------------------------------------------------------------------------------
+
+-- | A request to the Podman API
+podmanApiRequest :: Podman -> String -> IO (Response BL.ByteString)
+podmanApiRequest (Podman manager) uriPath =
+  let req = parseRequest_ ("http://127.0.0.1" <> uriPath)
+   in httpLbs req {requestHeaders = (hAccept, "application/json") : requestHeaders req} manager
+
+-- | Decode JSON, and throw an error if it can't be decoded.
+decodeWithError :: FromJSON a => BL.ByteString -> a
+decodeWithError = either error id . eitherDecode

--- a/src/lib/Ozymandias/Problem.hs
+++ b/src/lib/Ozymandias/Problem.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ozymandias.Problem where
+
+import Data.Aeson
+import Data.Text (Text, pack)
+import qualified Network.HTTP.Client as HTTP
+
+-- | All the problems that can arise.
+data Problem
+  = PodmanJsonError {jsonError :: String}
+  | PodmanHttpError {httpError :: HTTP.HttpException}
+  deriving (Show)
+
+instance ToJSON Problem where
+  toJSON = toJSON . toProblemDocument
+
+-- | A formatted problem, with help text and suchlike.
+data ProblemDocument = ProblemDocument
+  { -- | A URL which holds further information
+    problemType :: Text,
+    -- | The name of the problem
+    problemTitle :: Text,
+    -- | A description of the specific issue
+    problemDetail :: Text,
+    -- | Extra details (optional)
+    problemExtraDetails :: [(Text, Text)]
+  }
+  deriving (Show)
+
+instance ToJSON ProblemDocument where
+  toJSON doc =
+    object $
+      [ "type" .= problemType doc,
+        "title" .= problemTitle doc,
+        "detail" .= problemDetail doc
+      ]
+        ++ map (\(label, value) -> ("detail_" <> label) .= value) (problemExtraDetails doc)
+
+-- | Convert a @Problem@ into a @ProblemDocument@.
+toProblemDocument :: Problem -> ProblemDocument
+toProblemDocument (PodmanJsonError err) =
+  ProblemDocument
+    { problemType = problemTypeBaseURL <> "#podman-request-returned-invalid-json",
+      problemTitle = "Podman request returned invalid JSON",
+      problemDetail = pack err,
+      problemExtraDetails = []
+    }
+toProblemDocument (PodmanHttpError (HTTP.HttpExceptionRequest req err)) =
+  ProblemDocument
+    { problemType = problemTypeBaseURL <> "#podman-request-raised-an-http-error",
+      problemTitle = "Podman request raised an HTTP error",
+      problemDetail = pack (show err),
+      problemExtraDetails = [("request", pack (show req))]
+    }
+toProblemDocument (PodmanHttpError (HTTP.InvalidUrlException url err)) =
+  ProblemDocument
+    { problemType = problemTypeBaseURL <> "#invalid-url",
+      problemTitle = "Invalid URL",
+      problemDetail = pack err,
+      problemExtraDetails = [("url", pack url)]
+    }
+
+-- | Base URL for problem type help text
+problemTypeBaseURL :: Text
+problemTypeBaseURL = "https://github.com/barrucadu/ozymandias/master/docs/errors.markdown"

--- a/src/lib/Ozymandias/Problem.hs
+++ b/src/lib/Ozymandias/Problem.hs
@@ -13,7 +13,7 @@ data Problem
   | EtcdKeyNotFoundError Text
   | PodmanJsonError String
   | PodmanHttpError HTTP.HttpException
-  | JobDependencyError [[Text]] [Text]
+  | PodDependencyError [[Text]] [Text]
   deriving (Show)
 
 instance ToJSON Problem where
@@ -92,10 +92,10 @@ toProblemDocument (PodmanHttpError (HTTP.InvalidUrlException url err)) =
       problemDetail = pack err,
       problemExtraDetails = [("url", pack url)]
     }
-toProblemDocument (JobDependencyError solved unsolved) =
+toProblemDocument (PodDependencyError solved unsolved) =
   ProblemDocument
-    { problemType = problemTypeBaseURL <> "#job-has-unsatisfiable-dependencies",
-      problemTitle = "Job has unsatisfiable dependencies",
+    { problemType = problemTypeBaseURL <> "#pod-has-unsatisfiable-dependencies",
+      problemTitle = "Pod has unsatisfiable dependencies",
       problemDetail = "Could not compute a launch order for containers: " <> intercalate ", " unsolved,
       problemExtraDetails = [("launch_order", intercalate "; " (map (intercalate ", ") solved))]
     }

--- a/src/lib/Ozymandias/Util.hs
+++ b/src/lib/Ozymandias/Util.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ozymandias.Util
+  ( ApiHandle (..),
+    apiRequest,
+    apiRequest_,
+    apiRequest',
+
+    -- * Re-exports
+    methodGet,
+    methodPost,
+    methodDelete,
+    urlEncode,
+    newManager,
+    defaultManagerSettings,
+    parseUrlThrow,
+  )
+where
+
+import Control.Monad (void)
+import Data.Aeson (FromJSON, Value, eitherDecode, encode)
+import Data.ByteString.Lazy (ByteString)
+import Network.HTTP.Client
+import Network.HTTP.Types
+import Ozymandias.Monad
+import Ozymandias.Problem
+
+-- | A handle to an API.
+data ApiHandle = ApiHandle
+  { -- | Connection manager
+    apiManager :: Manager,
+    -- | Turn a request path into a request
+    apiMakeRequest :: String -> IO Request,
+    -- | Raise a JSON error
+    apiJsonError :: String -> Problem,
+    -- | Raise an HTTP error
+    apiHttpError :: HttpException -> Problem
+  }
+
+-- | Make an HTTP request and decode the response as JSON.
+apiRequest ::
+  FromJSON a =>
+  -- | API handle
+  ApiHandle ->
+  -- | Request method
+  Method ->
+  -- | Request path
+  String ->
+  -- | JSON request body
+  Maybe Value ->
+  Oz a
+apiRequest handle meth uriPath body = decodeJson =<< apiRequest' handle meth uriPath body
+  where
+    decodeJson = either (problem . apiJsonError handle) pure . eitherDecode . responseBody
+
+-- | Make an HTTP request, discarding the result.
+apiRequest_ ::
+  -- | API handle
+  ApiHandle ->
+  -- | Request method
+  Method ->
+  -- | Request path
+  String ->
+  -- | JSON request body
+  Maybe Value ->
+  Oz ()
+apiRequest_ handle meth uriPath body = void $ apiRequest' handle meth uriPath body
+
+-- | Make an HTTP request.
+apiRequest' ::
+  -- | API handle
+  ApiHandle ->
+  -- | Request method
+  Method ->
+  -- | Request path
+  String ->
+  -- | JSON request body
+  Maybe Value ->
+  Oz (Response ByteString)
+apiRequest' handle meth uriPath body = do
+  req <- makeReq <$> liftIO (apiMakeRequest handle uriPath)
+  liftIO (httpLbs req (apiManager handle)) `catch` (problem . apiHttpError handle)
+  where
+    makeReq req =
+      req
+        { method = meth,
+          requestHeaders = [(hAccept, "application/json"), (hContentType, "application/json")],
+          requestBody = maybe (requestBody req) (RequestBodyLBS . encode) body
+        }


### PR DESCRIPTION
This PR adds some debug commands which touch on major areas of functionality:

```
$ ozymandias --help
Usage: ozymandias COMMAND (-P|--podman-socket SOCKET) (-E|--etcd-host URL)
  A decentralised container scheduler

Available options:
  -P,--podman-socket SOCKET
                           Path to Podman socket
  -E,--etcd-host URL       URL of etcd host
  -h,--help                Show this help text

Available commands:
  debug                    Debugging commands

$ ozymandias debug --help
Usage: ozymandias debug COMMAND
  Debugging commands

Available options:
  -h,--help                Show this help text

Available commands:
  list-managed-pods        List running pods managed by the cluster
  list-unmanaged-pods      List running pods not managed by the cluster
  parse-pod-definition     Read and dump a pod configuration file
  create-pod-from-file     Create a pod from a configuration file
  create-pod-from-etcd     Create a pod from configuration in etcd
  destroy-pod              Kill and delete a running pod
```

With these commands we've got basic podman and etcd integration, and some of the types which will be needed going forward.

I think the logical next step after this is having a basic `ozymandias agent` command which watches for configuration changes in etcd and updates the local set of running pods (no scheduling yet).